### PR TITLE
Fixed bug in sync_cassandra command

### DIFF
--- a/cass.py
+++ b/cass.py
@@ -12,15 +12,15 @@ __all__ = ['get_user_by_username', 'get_friend_usernames',
     'save_tweet', 'add_friends', 'remove_friends', 'DatabaseError',
     'NotFound', 'InvalidDictionary', 'PUBLIC_USERLINE_KEY']
 
-CLIENT = pycassa.connect('Twissandra')
+CLIENT_POOL = pycassa.connect('Twissandra')
 
-USER = pycassa.ColumnFamily(CLIENT, 'User', dict_class=OrderedDict)
-USERNAME = pycassa.ColumnFamily(CLIENT, 'Username', dict_class=OrderedDict)
-FRIENDS = pycassa.ColumnFamily(CLIENT, 'Friends', dict_class=OrderedDict)
-FOLLOWERS = pycassa.ColumnFamily(CLIENT, 'Followers', dict_class=OrderedDict)
-TWEET = pycassa.ColumnFamily(CLIENT, 'Tweet', dict_class=OrderedDict)
-TIMELINE = pycassa.ColumnFamily(CLIENT, 'Timeline', dict_class=OrderedDict)
-USERLINE = pycassa.ColumnFamily(CLIENT, 'Userline', dict_class=OrderedDict)
+USER = pycassa.ColumnFamily(CLIENT_POOL, 'User', dict_class=OrderedDict)
+USERNAME = pycassa.ColumnFamily(CLIENT_POOL, 'Username', dict_class=OrderedDict)
+FRIENDS = pycassa.ColumnFamily(CLIENT_POOL, 'Friends', dict_class=OrderedDict)
+FOLLOWERS = pycassa.ColumnFamily(CLIENT_POOL, 'Followers', dict_class=OrderedDict)
+TWEET = pycassa.ColumnFamily(CLIENT_POOL, 'Tweet', dict_class=OrderedDict)
+TIMELINE = pycassa.ColumnFamily(CLIENT_POOL, 'Timeline', dict_class=OrderedDict)
+USERLINE = pycassa.ColumnFamily(CLIENT_POOL, 'Userline', dict_class=OrderedDict)
 
 # NOTE: Having a single userline key to store all of the public tweets is not
 #       scalable.  Currently, Cassandra requires that an entire row (meaning

--- a/tweets/management/commands/sync_cassandra.py
+++ b/tweets/management/commands/sync_cassandra.py
@@ -25,7 +25,8 @@ class Command(NoArgsCommand):
             column_families,
         )
         
-        client = pycassa.connect('system')
+        client_pool = pycassa.connect('system')
+        client = client_pool.get()
 
         # If there is already a Twissandra keyspace, we have to ask the user
         # what they want to do with it.


### PR DESCRIPTION
Howdy,

Great example project--thanks for doing it.

I found a small bug in it--the sync_cassandra command is trying to issue a describe_keyspace() and a system_drop_keyspace() against the pool, instead of a connection.

And I changed the name of your variable from CLIENT to CLIENT_POOL just to make that clear in cass.py. 

Thanks again!
