### PR TITLE
Refactor CLUSTER and SESSION to comply with PEP 8 naming conventions

### DIFF
--- a/cass.py
+++ b/cass.py
@@ -4,8 +4,8 @@ import random
 
 from cassandra.cluster import Cluster
 
-CLUSTER = Cluster(['127.0.0.1'])
-SESSION = CLUSTER.connect('twissandra')
+cluster = Cluster(['127.0.0.1'])
+session = cluster.connect('twissandra')
 
 # NOTE: Having a single userline key to store all of the public tweets is not
 #       scalable.  This result in all public tweets being stored in a single
@@ -52,7 +52,7 @@ def _get_line(table, username, start, limit):
 
     query = query.format(table=table, time_clause=time_clause)
 
-    results = SESSION.execute(query, params)
+    results = session.execute(query, params)
     if not results:
         return [], None
 
@@ -69,7 +69,7 @@ def _get_line(table, username, start, limit):
     # Now we fetch the tweets themselves
     futures = []
     for row in results:
-        futures.append(SESSION.execute_async(
+        futures.append(session.execute_async(
             "SELECT * FROM tweets WHERE tweet_id=%s", (row.tweet_id, )))
 
     tweets = [f.result()[0] for f in futures]
@@ -82,7 +82,7 @@ def get_user_by_username(username):
     """
     Given a username, this gets the user record.
     """
-    rows = SESSION.execute("SELECT * FROM users WHERE username=%s", (username, ))
+    rows = session.execute("SELECT * FROM users WHERE username=%s", (username, ))
     if not rows:
         raise NotFound('User %s not found' % (username,))
     else:
@@ -94,7 +94,7 @@ def get_friend_usernames(username, count=5000):
     Given a username, gets the usernames of the people that the user is
     following.
     """
-    rows = SESSION.execute(
+    rows = session.execute(
         "SELECT friend FROM friends WHERE username=%s LIMIT %s",
         (username, count))
     return [row.friend for row in rows]
@@ -104,7 +104,7 @@ def get_follower_usernames(username, count=5000):
     """
     Given a username, gets the usernames of the people following that user.
     """
-    rows = SESSION.execute(
+    rows = session.execute(
         "SELECT follower FROM followers WHERE username=%s LIMIT %s",
         (username, count))
     return [row.follower for row in rows]
@@ -117,7 +117,7 @@ def get_users_for_usernames(usernames):
     """
     futures = []
     for user in usernames:
-        future = SESSION.execute_async("SELECT * FROM users WHERE username=%s", (user, ))
+        future = session.execute_async("SELECT * FROM users WHERE username=%s", (user, ))
         futures.append(future)
 
     users = []
@@ -164,7 +164,7 @@ def get_tweet(tweet_id):
     """
     Given a tweet id, this gets the entire tweet record.
     """
-    results = SESSION.execute("SELECT * FROM tweets WHERE tweet_id=%s", (tweet_id, ))
+    results = session.execute("SELECT * FROM tweets WHERE tweet_id=%s", (tweet_id, ))
     if not results:
         raise NotFound('Tweet %s not found' % (tweet_id,))
     else:
@@ -178,7 +178,7 @@ def get_tweets_for_tweet_ids(tweet_ids):
     """
     futures = []
     for tweet_id in tweet_ids:
-        futures.append(SESSION.execute_async(
+        futures.append(session.execute_async(
             "SELECT * FROM tweets WHERE tweet_id=%s", (tweet_id, )))
 
     tweets = []
@@ -198,7 +198,7 @@ def save_user(username, password):
     """
     Saves the user record.
     """
-    SESSION.execute(
+    session.execute(
         "INSERT INTO users (username, password) VALUES (%s, %s)",
         (username, password))
 
@@ -231,15 +231,15 @@ def save_tweet(tweet_id, username, tweet, timestamp=None):
         now = _timestamp_to_uuid(timestamp)
 
     # Insert the tweet, then into the user's timeline, then into the public one
-    SESSION.execute(
+    session.execute(
         "INSERT INTO tweets (tweet_id, username, body) VALUES (%s, %s, %s)",
         (tweet_id, username, tweet))
 
-    SESSION.execute(
+    session.execute(
         "INSERT INTO userline (username, time, tweet_id) VALUES (%s, %s, %s)",
         (username, now, tweet_id))
 
-    SESSION.execute(
+    session.execute(
         "INSERT INTO userline (username, time, tweet_id) VALUES (%s, %s, %s)",
         (PUBLIC_USERLINE_KEY, now, tweet_id))
 
@@ -247,7 +247,7 @@ def save_tweet(tweet_id, username, tweet, timestamp=None):
     futures = []
     follower_usernames = [username] + get_follower_usernames(username)
     for follower_username in follower_usernames:
-        futures.append(SESSION.execute_async(
+        futures.append(session.execute_async(
             "INSERT INTO timeline (username, time, tweet_id) VALUES (%s, %s, %s)",
             (follower_username, now, tweet_id)))
 
@@ -262,11 +262,11 @@ def add_friends(from_username, to_usernames):
     now = datetime.utcnow()
     futures = []
     for to_user in to_usernames:
-        futures.append(SESSION.execute_async(
+        futures.append(session.execute_async(
             "INSERT INTO friends (username, friend, since) VALUES (%s, %s, %s)",
             (from_username, to_user, now)))
 
-        futures.append(SESSION.execute_async(
+        futures.append(session.execute_async(
             "INSERT INTO followers (username, follower, since) VALUES (%s, %s, %s)",
             (to_user, from_username, now)))
 
@@ -280,11 +280,11 @@ def remove_friends(from_username, to_usernames):
     """
     futures = []
     for to_user in to_usernames:
-        futures.append(SESSION.execute_async(
+        futures.append(session.execute_async(
             "DELETE FROM friends WHERE username=%s AND friend=%s",
             (from_username, to_user)))
 
-        futures.append(SESSION.execute_async(
+        futures.append(session.execute_async(
             "DELETE FROM followers WHERE username=%s AND follower=%s",
             (to_user, from_username)))
 


### PR DESCRIPTION
Simple as the title. Just lowercases the SESSION and CLUSTER objects in cass.py.
